### PR TITLE
use truncated content as excerpt if excerpt is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ algolia:
   adminApiKey: "40321c7c207e7f73b63a19aa24c4761b"
   chunkSize: 5000
   indexName: "my-hexo-blog"
+  excerptLimit: 200
+  excerptSeparator: ''
   fields:
     - title
     - tags

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ algolia:
 | apiKey         | String |         | Your API key (read only). It is use to search in an index. |
 | adminApiKey    | String |         | Your adminAPI key. It is use to create, delete, update your indexes |
 | chunkSize      | Number | 5000    | Records/posts are split in chunks to upload them. Algolia recommend to use `5000` for best performance. Be careful, if you are indexing post content, It can fail because of size limit. To overcome this, decrease size of chunks until it pass. |
+| excerptLimit   | Number |         | The number of words or characters to strip for the excerpt. Default to `200`. |
+| excerptSeparator   | String |         | Separator between words. Use `' '` so that excerptLimit becomes English word count. Default to `''` so that excerptLimit is character count. |
 | indexName      | String |         | The name of the index in which posts are stored. |
 | fields         | List   |         | The list of the field names to index. Separate field name and action name with `:`. Read [Actions](#actions) for more information |
 

--- a/lib/algolia.js
+++ b/lib/algolia.js
@@ -69,11 +69,11 @@ function algolia(args, callback) {
         var fieldContent = post[fieldName];
         // handle cases when the excerpt may not exist
         // if <!--more--> is not present
-        if (fieldName === "excerpt" && fieldContent === "") {
+        if (fieldName === 'excerpt' && fieldContent === '') {
           fieldContent = hexoUtil.truncate(hexoUtil.stripHTML(post.content), {
-            length: 200,
-            omission: "...",
-            separator: " "
+            length: algoliaConfig.excerptLimit || 200,
+            omission: '...',
+            separator: algoliaConfig.excerptSeparator || ''
           });
         }
         // execute action function on post field

--- a/lib/algolia.js
+++ b/lib/algolia.js
@@ -66,9 +66,21 @@ function algolia(args, callback) {
         var fieldName = field[0];
         var actionName = field[1];
         var actionFn = actions[actionName];
+        var fieldContent = post[fieldName];
+        // handle cases when the excerpt may not exist
+        // if <!--more--> is not present
+        if (fieldName === "excerpt" && fieldContent === "") {
+          fieldContent = hexoUtil.truncate(hexoUtil.stripHTML(post.content), {
+            length: 200,
+            omission: "...",
+            separator: " "
+          });
+        }
         // execute action function on post field
         // and store result in post object
-        object[fieldName + _.upperFirst(actionName)] = actionFn(post[fieldName]);
+        if (actionFn instanceof Function) {
+          object[fieldName + _.upperFirst(actionName)] = actionFn(fieldContent);
+        }
       }
     }
     return object;


### PR DESCRIPTION
The excerpt might be empty if no `<!--more-->` is present. In this case, use truncated and stripped content as excerpt. 
@LouisBarranqueiro

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/hexo-algoliasearch/7)

<!-- Reviewable:end -->
