### PR TITLE
Add Support for Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ algolia:
 
 | Key            | Type   | Default | Description |
 | -------------- | ------ | ------- | ----------- |
-| appId          | String |         | Your application ID. |
-| apiKey         | String |         | Your API key (read only). It is use to search in an index. |
-| adminApiKey    | String |         | Your adminAPI key. It is use to create, delete, update your indexes |
+| appId          | String |         | Your application ID. Optional, if the environment variable ALGOLIA_APP_ID is set|
+| apiKey         | String |         | Your API key (read only). It is use to search in an index. Optional, if the environment variable ALGOLIA_API_KEY is set|
+| adminApiKey    | String |         | Your adminAPI key. It is use to create, delete, update your indexes. Optional, if the environment variable ALGOLIA_ADMIN_API_KEY is set |
 | chunkSize      | Number | 5000    | Records/posts are split in chunks to upload them. Algolia recommend to use `5000` for best performance. Be careful, if you are indexing post content, It can fail because of size limit. To overcome this, decrease size of chunks until it pass. |
-| indexName      | String |         | The name of the index in which posts are stored. |
+| indexName      | String |         | The name of the index in which posts are stored. Optional, if the environment variable ALGOLIA_INDEX_NAME is set|
 | fields         | List   |         | The list of the field names to index. Separate field name and action name with `:`. Read [Actions](#actions) for more information |
 
 #### Actions
 
-Actions give you the ability to process value of a fields before indexation. 
+Actions give you the ability to process value of a fields before indexation.
 
 ##### List of actions :
 

--- a/lib/algolia.js
+++ b/lib/algolia.js
@@ -15,10 +15,11 @@ function algolia(args, callback) {
   var algoliaConfig = hexo.config.algolia;
   var fields = getFields(algoliaConfig.fields);
   var customFields = getCustomFields(algoliaConfig.fields);
-  // Get user defined variables from _config.yml OR env variables
-  var appId = algoliaConfig.appId || process.env.ALGOLIA_APP_ID;
-  var adminApiKey = algoliaConfig.adminApiKey || process.env.ALGOLIA_ADMIN_API_KEY;
-  var indexName = algoliaConfig.indexName || process.env.ALGOLIA_INDEX_NAME;
+  // Get user defined variables from env variables OR _config.yml
+  // Note: That we will ignore any information set into _config.yml if the user setted the env variables.
+  var appId = process.env.ALGOLIA_APP_ID || algoliaConfig.appId;
+  var adminApiKey = process.env.ALGOLIA_ADMIN_API_KEY || algoliaConfig.adminApiKey;
+  var indexName = process.env.ALGOLIA_INDEX_NAME || algoliaConfig.indexName;
   var log = hexo.log;
   var posts = [];
   var actions = [];

--- a/lib/algolia.js
+++ b/lib/algolia.js
@@ -16,6 +16,7 @@ function algolia(args, callback) {
   var fields = getFields(algoliaConfig.fields);
   var customFields = getCustomFields(algoliaConfig.fields);
   // Get user defined variables from _config.yml OR env variables
+  var apiKey = algoliaConfig.apiKey || process.env.ALGOLIA_API_KEY;
   var appId = algoliaConfig.appId || process.env.ALGOLIA_APP_ID;
   var adminApiKey = algoliaConfig.adminApiKey || process.env.ALGOLIA_ADMIN_API_KEY;
   var indexName = algoliaConfig.indexName || process.env.ALGOLIA_INDEX_NAME;

--- a/lib/algolia.js
+++ b/lib/algolia.js
@@ -16,7 +16,6 @@ function algolia(args, callback) {
   var fields = getFields(algoliaConfig.fields);
   var customFields = getCustomFields(algoliaConfig.fields);
   // Get user defined variables from _config.yml OR env variables
-  var apiKey = algoliaConfig.apiKey || process.env.ALGOLIA_API_KEY;
   var appId = algoliaConfig.appId || process.env.ALGOLIA_APP_ID;
   var adminApiKey = algoliaConfig.adminApiKey || process.env.ALGOLIA_ADMIN_API_KEY;
   var indexName = algoliaConfig.indexName || process.env.ALGOLIA_INDEX_NAME;

--- a/lib/algolia.js
+++ b/lib/algolia.js
@@ -15,6 +15,10 @@ function algolia(args, callback) {
   var algoliaConfig = hexo.config.algolia;
   var fields = getFields(algoliaConfig.fields);
   var customFields = getCustomFields(algoliaConfig.fields);
+  // Get user defined variables from _config.yml OR env variables
+  var appId = algoliaConfig.appId || process.env.ALGOLIA_APP_ID;
+  var adminApiKey = algoliaConfig.adminApiKey || process.env.ALGOLIA_ADMIN_API_KEY;
+  var indexName = algoliaConfig.indexName || process.env.ALGOLIA_INDEX_NAME;
   var log = hexo.log;
   var posts = [];
   var actions = [];
@@ -116,9 +120,9 @@ function algolia(args, callback) {
 
     log.info(posts.length + ' posts collected');
     // init index
-    var client = algoliasearch(algoliaConfig.appId, algoliaConfig.adminApiKey);
-    var index = client.initIndex(algoliaConfig.indexName);
-    
+    var client = algoliasearch(appId, adminApiKey);
+    var index = client.initIndex(indexName);
+
     // clear index
     if (args && !args.n) {
       log.info('Clearing index on Algolia...');

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash": "^4.13.1"
   },
   "devDependencies": {
-    "eslint": "2.13.1",
+    "eslint": "3.8.1",
     "eslint-config-google": "^0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lodash": "^4.13.1"
   },
   "devDependencies": {
+    "eslint": "2.13.1",
     "eslint-config-google": "^0.6.0"
   }
 }


### PR DESCRIPTION
In order to increase security and the flexibility of the plugins. I added support for environment variables. For the given variables:
- apiKey -> ALGOLIA_API_KEY
- appId -> ALGOLIA_APP_ID
- adminApiKey -> ALGOLIA_ADMIN_API_KEY
- indexName -> ALGOLIA_INDEX_NAME

The advantage of using environment variables, is that the user can keep their website on a public repo, and don't have to worry about their Algolia index info being leaked, specially the adminApiKey.

p.s: I added `eslint` to the DevDependencies, since it's necessaaary for working on the project.

Please let me know if there is anything missing. I'm more than happy to do anything in my power to have this feature accepted 😄 
