### PR TITLE
ignore hidden post

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install hexo-algoliasearch --save
 If Hexo detect automatically all plugins, that's all.
 
 If that is not the case, register the plugin in your `_config.yml` file :
-```yml
+```
 plugins:
   - hexo-algoliasearch
 ```
@@ -29,6 +29,7 @@ algolia:
   adminApiKey: "40321c7c207e7f73b63a19aa24c4761b"
   chunkSize: 5000
   indexName: "my-hexo-blog"
+  hidden: "hidden"
   fields:
     - content:strip:truncate,0,500
     - excerpt:strip
@@ -47,6 +48,7 @@ algolia:
 | adminApiKey    | String |         | Your adminAPI key. It is use to create, delete, update your indexes. Optional, if the environment variable `ALGOLIA_ADMIN_API_KEY` is set |
 | chunkSize      | Number | 5000    | Records/posts are split in chunks to upload them. Algolia recommend to use `5000` for best performance. Be careful, if you are indexing post content, It can fail because of size limit. To overcome this, decrease size of chunks until it pass. |
 | indexName      | String |         | The name of the index in which posts are stored. Optional, if the environment variable `ALGOLIA_INDEX_NAME` is set|
+| indexName      | String | hidden | ignore indexing|
 | fields         | List   |         | The list of the field names to index. Separate field name and filters with `:`. Read [Filters](#filters) for more information |
 
 #### Filters

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ algolia:
 | adminApiKey    | String |         | Your adminAPI key. It is use to create, delete, update your indexes. Optional, if the environment variable `ALGOLIA_ADMIN_API_KEY` is set |
 | chunkSize      | Number | 5000    | Records/posts are split in chunks to upload them. Algolia recommend to use `5000` for best performance. Be careful, if you are indexing post content, It can fail because of size limit. To overcome this, decrease size of chunks until it pass. |
 | indexName      | String |         | The name of the index in which posts are stored. Optional, if the environment variable `ALGOLIA_INDEX_NAME` is set|
-| indexName      | String | hidden | ignore indexing|
+| hidden         | String | hidden  | ignore indexing|
 | fields         | List   |         | The list of the field names to index. Separate field name and filters with `:`. Read [Filters](#filters) for more information |
 
 #### Filters

--- a/src/algolia.js
+++ b/src/algolia.js
@@ -132,11 +132,17 @@ const algoliaCommand = async(hexo, args, callback) => {
   const algoliaIndexName = process.env.ALGOLIA_INDEX_NAME || algoliaConfig.indexName
   // Algolia recommendation: split posts into chunks of 5000 to get a good indexing/insert performance
   const algoliaChunkSize = algoliaConfig.chunkSize || 5000
+  const hiddenKey = algoliaConfig.hidden || 'hidden'
 
   await hexo.call('generate')
   await hexo.database.load()
 
-  let posts = hexo.database.model('Post').find({published: true}).sort('date', 'asc').toArray()
+  let posts = hexo.database.model('Post').find({
+    published: true,
+    [hiddenKey]: {
+      $ne: true
+    }
+  }).sort('date', 'asc').toArray()
 
   if (!posts.length) {
     hexo.log.info('There is no post to index.')


### PR DESCRIPTION
### Related issues:  #135 
### Changes
Some articles are hidden using plugins, but they will still be indexed, so i just add a fitter in  hexo.database.model('...').find(...)

### Testing guide
add a hidden tag in any post like `hidden: true`, execute `hexo g` and then `hexo algolia`, this post will be ignore when indexing

<!-- IMPORTANT: Make sure you've done all the things listed below before creating a pull request --> 
### Checklist
- [x] I updated the README <!-- if applicable -->
- [x] I tested my changes with the current recommended Node LTS version: <!-- Specify the version you used -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/louisbarranqueiro/hexo-algoliasearch/136)
<!-- Reviewable:end -->
