### PR TITLE
fix: remove the generate step #173

### DIFF
--- a/src/algolia.js
+++ b/src/algolia.js
@@ -133,7 +133,6 @@ const algoliaCommand = async(hexo, args, callback) => {
   // Algolia recommendation: split posts into chunks of 5000 to get a good indexing/insert performance
   const algoliaChunkSize = algoliaConfig.chunkSize || 5000
 
-  await hexo.call('generate')
   await hexo.database.load()
 
   let posts = hexo.database.model('Post').find({published: true}).sort('date', 'asc').toArray()


### PR DESCRIPTION
### Related issues: <!-- Reference any related issues. E.g: #4515 (if applicable) --> 
#173
### Changes
<!-- Describe and explain the changes you made. --> 
<!-- Add some screenshots to explain your changes. (if applicable) --> 
The `hexo algolia` will generate the static files but not `db.json`,which means that, to make it work,we still need to run `hexo generate` first,so I removed this to seperate it from the generatation step to make it more reasonable in the workflow and etc.Just make it work as a search-data sender.

<!-- IMPORTANT: Make sure you've done all the things listed below before creating a pull request --> 
### Checklist
- [x] I tested my changes with the current recommended Node LTS version: <!-- Specify the version you used -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/LouisBarranqueiro/hexo-algoliasearch/174)
<!-- Reviewable:end -->
